### PR TITLE
Support for ERB style templates; return source data item in callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,29 +45,36 @@ Description: The object property to match the query against.
 Default: *name*<br />
 Description: The object property to use when sorting the items.
 
+**template**<br />
+Default: *'<%= matchProp %>'*<br />
+Description: An html string for the list item. Object properties can be supplied in ERB-style tags, 
+and will be rendered from the source data passed in. matchProp is a magic property that converts to whatever the defined matchProp option is set to.<br />
+
 **itemSelected**<br />
-Default: *function (item, val, text) {}*<br />
+Default: *function (element, val, text, item) {}*<br />
 Description: The callback function that is invoked when an item is chosen.<br />
 
-+ item: the HTML element that was selected
++ element: the HTML element that was selected
 
 + val: value of the *valueProp* property
 
 + text: value of the *textProp* property
 
++ item: the source data object for the selected entry
+
 Sample Usage
 ------------
     var cities = [
-			{ID: 1, Name: 'Toronto'},
-			{ID: 2, Name: 'Montreal'},
-			{ID: 3, Name: 'New York'},
-			{ID: 4, Name: 'Buffalo'},
-			{ID: 5, Name: 'Boston'},
-			{ID: 6, Name: 'Columbus'},
-			{ID: 7, Name: 'Dallas'},
-			{ID: 8, Name: 'Vancouver'},
-			{ID: 9, Name: 'Seattle'},
-			{ID: 10, Name: 'Los Angeles'}
+			{ID: 1, Name: 'Toronto', Country: 'Canada'},
+			{ID: 2, Name: 'Montreal', Country: 'Canada'},
+			{ID: 3, Name: 'New York', Country: 'USA'},
+			{ID: 4, Name: 'Buffalo', Country: 'USA'},
+			{ID: 5, Name: 'Boston', Country: 'USA'},
+			{ID: 6, Name: 'Columbus', Country: 'USA'},
+			{ID: 7, Name: 'Dallas', Country: 'USA'},
+			{ID: 8, Name: 'Vancouver', Country: 'USA'},
+			{ID: 9, Name: 'Seattle', Country: 'USA'},
+			{ID: 10, Name: 'Los Angeles', Country: 'USA'}
 	    ]
 
 	$(function() {
@@ -76,8 +83,8 @@ Sample Usage
 			matchProp: 'Name',
 			sortProp: 'Name',
 			valueProp: 'ID',
-			itemSelected: function(item, val, text) {
-				alert('You selected the city ' + text + ' with ID ' + val)
+			itemSelected: function(element, val, text, item) {
+				alert('You selected the city ' + text + '('+ item.Country +') with ID ' + val + '')
 				console.log(item)
 			}
 		})

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Typeahead
 An extension of the Twitter Bootstrap Typeahead plugin (as of v2.0.2)<br />
 <http://twitter.github.com/bootstrap/javascript.html#typeahead>
 
+Demo
+-----------------
+http://tcrosen.github.com/twitter-bootstrap-typeahead/
+
 Required
 -----------------
 * Twitter Bootstrap 2.0.2+
@@ -79,4 +83,4 @@ Sample Usage
 		})
 	})
 
-A full working example is included in this project.
+A full working example is included in this project and is now available at http://tcrosen.github.com/twitter-bootstrap-typeahead/

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -5,7 +5,6 @@
 		Bootstrap Typeahead Extension Demo
 	</title>
 	<link href="css/bootstrap.css" rel="stylesheet">
-	<link href="css/demo.css" rel="stylesheet">
 	<script src="js/jquery-1.7.1.min.js" type="text/javascript"></script>
 	<script src="js/bootstrap-typeahead.js" type="text/javascript"></script>
 	<script src="js/demo.js" type="text/javascript"></script>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -5,6 +5,7 @@
 		Bootstrap Typeahead Extension Demo
 	</title>
 	<link href="css/bootstrap.css" rel="stylesheet">
+	<link href="css/demo.css" rel="stylesheet">
 	<script src="js/jquery-1.7.1.min.js" type="text/javascript"></script>
 	<script src="js/bootstrap-typeahead.js" type="text/javascript"></script>
 	<script src="js/demo.js" type="text/javascript"></script>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -38,5 +38,11 @@
 		<input type="text" class="span3 states" placeholder="Search states..." />
 	</div>
 
+	<h3>With Custom Templates</h3>
+
+	<div class="well">
+		<input type="text" class="span3 template-states" placeholder="Search states..." />
+	</div>
+
 </body>
 </html>

--- a/demo/js/bootstrap-typeahead.js
+++ b/demo/js/bootstrap-typeahead.js
@@ -39,9 +39,9 @@ function($) {
 
       var selectedSource = $.grep(this.source, function(item) {
         return item[_this.options.valueProp] == $selectedItem.attr('data-value')
-      })[0]
+      })[0] || $selectedItem.text()
 
-      this.$element.val(selectedSource[this.options.matchProp])
+      this.$element.val(selectedSource[this.options.matchProp] || selectedSource)
 
       this.options.itemSelected($selectedItem, $selectedItem.attr('data-value'), selectedSource[this.options.matchProp], selectedSource)
       return this.hide()

--- a/demo/js/bootstrap-typeahead.js
+++ b/demo/js/bootstrap-typeahead.js
@@ -14,16 +14,17 @@ function($) {
   "use strict"
 
   var Typeahead = function(element, options) {
-      this.$element =     $(element)
-      this.options =      $.extend({}, $.fn.typeahead.defaults, options)
-      this.$menu =        $(this.options.menu).appendTo('body')      
-      this.source =       this.options.source
-      this.shown =        false
-      this.matcher =      this.options.matcher      || this.matcher
-      this.sorter =       this.options.sorter       || this.sorter
-      this.highlighter =  this.options.highlighter  || this.highlighter
-      this.select =       this.options.select       || this.select
-      this.render =       this.options.render       || this.render  
+      this.$element =       $(element)
+      this.options =        $.extend({}, $.fn.typeahead.defaults, options)
+      this.options.template = this.options.template.replace("matchProp", this.options.matchProp)
+      this.$menu =          $(this.options.menu).appendTo('body')      
+      this.source =         this.options.source
+      this.shown =          false
+      this.matcher =        this.options.matcher      || this.matcher
+      this.sorter =         this.options.sorter       || this.sorter
+      this.highlighter =    this.options.highlighter  || this.highlighter
+      this.select =         this.options.select       || this.select
+      this.render =         this.options.render       || this.render  
       this.listen()
     }
 
@@ -120,6 +121,55 @@ function($) {
       })
     }
 
+
+    // Simple JavaScript Templating
+    // John Resig - http://ejohn.org/ - MIT Licensed
+    ,
+    _tmplCache: {}
+
+    ,
+    _tmpl: function(str,data) {
+       // Figure out if we're getting a template, or if we need to
+      // load the template - and be sure to cache the result.
+      var fn = !/\W/.test(str) ?
+        this._templCache[str] = this._templCache[str] ||
+          this._tmpl(document.getElementById(str).innerHTML) :
+        
+        // Generate a reusable function that will serve as a template
+        // generator (and which will be cached).
+        new Function("obj",
+          "var p=[],print=function(){p.push.apply(p,arguments);};" +
+          
+          // Introduce the data as local variables using with(){}
+          "with(obj){p.push('" +
+          
+          // Convert the template into pure JavaScript
+          str
+            .replace(/[\r\t\n]/g, " ")
+            .split("<%").join("\t")
+            .replace(/((^|%>)[^\t]*)'/g, "$1\r")
+            .replace(/\t=(.*?)%>/g, "',$1,'")
+            .split("\t").join("');")
+            .split("%>").join("p.push('")
+            .split("\r").join("\\'")
+        + "');}return p.join('');");
+      
+      // Provide some basic currying to the user
+      return data ? fn( data ) : fn;
+    }
+
+    ,
+    renderTemplate: function(item){
+      //leverage underscore's implementation for templating if possible
+      if (window._ != null && typeof window._.template === "function" ) {
+         return _(this.options.template).template(item)
+      //If they're working without underscore (really? wtf-sad-haxors :'( ),use
+      // j.resigs super-dope micro-templating (which is coincidentally what underscore uses)
+      } else {
+        return this._tmpl(this.options.template, item);
+      }
+    }
+
     ,
     render: function(items) {
       var _this = this
@@ -127,7 +177,9 @@ function($) {
       items = $(items).map(function(i, item) {
         i = $(_this.options.item).attr('data-value', item[_this.options.valueProp] || item)
         if (i) {
-          i.find('a').html(_this.highlighter(item[_this.options.matchProp] || item))
+          var matchItem = $.extend({}, item);
+          matchItem[_this.options.valueProp] = _this.highlighter(item[_this.options.matchProp] || item) //store as a prop on the item
+          i.find('a').html(_this.renderTemplate(item)); 
           return i[0]
         }
       })
@@ -275,7 +327,8 @@ function($) {
     source: [],
     items: 8,
     menu: '<ul class="typeahead dropdown-menu"></ul>',
-    item: '<li><a href="#"></a></li>',
+    item: '<li><a href="#"></a></li>', 
+    template: '<%= matchProp %>', //matchProp is a magic template var switched to use the matchProp specified;
     matchProp: 'name',
     sortProp: 'name',
     valueProp: 'id',

--- a/demo/js/bootstrap-typeahead.js
+++ b/demo/js/bootstrap-typeahead.js
@@ -35,8 +35,15 @@ function($) {
     ,
     select: function() {
       var $selectedItem = this.$menu.find('.active')
-      this.$element.val($selectedItem.text())
-      this.options.itemSelected($selectedItem, $selectedItem.attr('data-value'), $selectedItem.text())
+      var _this = this;
+
+      var selectedSource = $.grep(this.source, function(item) {
+        return item[_this.options.valueProp] == $selectedItem.attr('data-value')
+      })[0]
+
+      this.$element.val(selectedSource[this.options.matchProp])
+
+      this.options.itemSelected($selectedItem, $selectedItem.attr('data-value'), selectedSource[this.options.matchProp], selectedSource)
       return this.hide()
     }
 

--- a/demo/js/bootstrap-typeahead.js
+++ b/demo/js/bootstrap-typeahead.js
@@ -178,8 +178,8 @@ function($) {
         i = $(_this.options.item).attr('data-value', item[_this.options.valueProp] || item)
         if (i) {
           var matchItem = $.extend({}, item);
-          matchItem[_this.options.valueProp] = _this.highlighter(item[_this.options.matchProp] || item) //store as a prop on the item
-          i.find('a').html(_this.renderTemplate(item)); 
+          matchItem[_this.options.matchProp] = _this.highlighter(item[_this.options.matchProp] || item) //store as a prop on the item
+          i.find('a').html(_this.renderTemplate(matchItem)); 
           return i[0]
         }
       })

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -43,4 +43,16 @@ $(function() {
 			console.log(item)
 		}
 	});
+
+	$('.template-states').typeahead({
+		source: states,
+		matchProp: 'full_name',
+		sortProp: 'abbrev',
+		template: '<h3><%= abbrev %></h3><%= matchProp %>', //Note that matchProp is a magic element which automatically maps to the specified matchProp
+		itemSelected: function(item, val, text) {
+			$('.selected-message').html('You selected the state ' + text + ' with ID ' + val + '<br />View your browser console for the full item element.')
+								  .show();
+			console.log(item)
+		}
+	});
 })

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -26,7 +26,7 @@ $(function() {
 		matchProp: 'Name',
 		sortProp: 'Name',
 		valueProp: 'ID',
-		itemSelected: function(item, val, text) {
+		itemSelected: function(el, val, text, item) {
 			$('.selected-message').html('You selected the city ' + text + ' with ID ' + val + '<br />View your browser console for the full item element.')
 								  .show();
 			console.log(item)
@@ -37,7 +37,7 @@ $(function() {
 		source: states,
 		matchProp: 'full_name',
 		sortProp: 'abbrev',
-		itemSelected: function(item, val, text) {
+		itemSelected: function(el, val, text, item) {
 			$('.selected-message').html('You selected the state ' + text + ' with ID ' + val + '<br />View your browser console for the full item element.')
 								  .show();
 			console.log(item)
@@ -49,7 +49,7 @@ $(function() {
 		matchProp: 'full_name',
 		sortProp: 'abbrev',
 		template: '<h3><%= abbrev %></h3><%= matchProp %>', //Note that matchProp is a magic element which automatically maps to the specified matchProp
-		itemSelected: function(item, val, text) {
+		itemSelected: function(el, val, text, item) {
 			$('.selected-message').html('You selected the state ' + text + ' with ID ' + val + '<br />View your browser console for the full item element.')
 								  .show();
 			console.log(item)

--- a/lib/bootstrap-typeahead.js
+++ b/lib/bootstrap-typeahead.js
@@ -14,16 +14,17 @@ function($) {
   "use strict"
 
   var Typeahead = function(element, options) {
-      this.$element =     $(element)
-      this.options =      $.extend({}, $.fn.typeahead.defaults, options)
-      this.$menu =        $(this.options.menu).appendTo('body')      
-      this.source =       this.options.source
-      this.shown =        false
-      this.matcher =      this.options.matcher      || this.matcher
-      this.sorter =       this.options.sorter       || this.sorter
-      this.highlighter =  this.options.highlighter  || this.highlighter
-      this.select =       this.options.select       || this.select
-      this.render =       this.options.render       || this.render  
+      this.$element =       $(element)
+      this.options =        $.extend({}, $.fn.typeahead.defaults, options)
+      this.options.template = this.options.template.replace("matchProp", this.options.matchProp)
+      this.$menu =          $(this.options.menu).appendTo('body')      
+      this.source =         this.options.source
+      this.shown =          false
+      this.matcher =        this.options.matcher      || this.matcher
+      this.sorter =         this.options.sorter       || this.sorter
+      this.highlighter =    this.options.highlighter  || this.highlighter
+      this.select =         this.options.select       || this.select
+      this.render =         this.options.render       || this.render  
       this.listen()
     }
 
@@ -120,6 +121,55 @@ function($) {
       })
     }
 
+
+    // Simple JavaScript Templating
+    // John Resig - http://ejohn.org/ - MIT Licensed
+    ,
+    _tmplCache: {}
+
+    ,
+    _tmpl: function(str,data) {
+       // Figure out if we're getting a template, or if we need to
+      // load the template - and be sure to cache the result.
+      var fn = !/\W/.test(str) ?
+        this._templCache[str] = this._templCache[str] ||
+          this._tmpl(document.getElementById(str).innerHTML) :
+        
+        // Generate a reusable function that will serve as a template
+        // generator (and which will be cached).
+        new Function("obj",
+          "var p=[],print=function(){p.push.apply(p,arguments);};" +
+          
+          // Introduce the data as local variables using with(){}
+          "with(obj){p.push('" +
+          
+          // Convert the template into pure JavaScript
+          str
+            .replace(/[\r\t\n]/g, " ")
+            .split("<%").join("\t")
+            .replace(/((^|%>)[^\t]*)'/g, "$1\r")
+            .replace(/\t=(.*?)%>/g, "',$1,'")
+            .split("\t").join("');")
+            .split("%>").join("p.push('")
+            .split("\r").join("\\'")
+        + "');}return p.join('');");
+      
+      // Provide some basic currying to the user
+      return data ? fn( data ) : fn;
+    }
+
+    ,
+    renderTemplate: function(item){
+      //leverage underscore's implementation for templating if possible
+      if (_ != null && typeof _.template === "function" ) {
+         return _(this.options.template).template(item)
+      //If they're working without underscore (really? wtf-sad-haxors :'( ),use
+      // j.resigs super-dope micro-templating (which is coincidentally what underscore uses)
+      } else {
+        return this._tmpl(this.options.template, item);
+      }
+    }
+
     ,
     render: function(items) {
       var _this = this
@@ -127,7 +177,9 @@ function($) {
       items = $(items).map(function(i, item) {
         i = $(_this.options.item).attr('data-value', item[_this.options.valueProp] || item)
         if (i) {
-          i.find('a').html(_this.highlighter(item[_this.options.matchProp] || item))
+          var matchItem = $.extend({}, item);
+          matchItem[_this.options.valueProp] = _this.highlighter(item[_this.options.matchProp] || item) //store as a prop on the item
+          i.find('a').html(_this.renderTemplate(item)); 
           return i[0]
         }
       })
@@ -275,7 +327,8 @@ function($) {
     source: [],
     items: 8,
     menu: '<ul class="typeahead dropdown-menu"></ul>',
-    item: '<li><a href="#"></a></li>',
+    item: '<li><a href="#"></a></li>', 
+    template: '<%= matchProp %>', //matchProp is a magic template var switched to use the matchProp specified;
     matchProp: 'name',
     sortProp: 'name',
     valueProp: 'id',

--- a/lib/bootstrap-typeahead.js
+++ b/lib/bootstrap-typeahead.js
@@ -39,9 +39,9 @@ function($) {
 
       var selectedSource = $.grep(this.source, function(item) {
         return item[_this.options.valueProp] == $selectedItem.attr('data-value')
-      })[0]
+      })[0] || $selectedItem.text()
 
-      this.$element.val(selectedSource[this.options.matchProp])
+      this.$element.val(selectedSource[this.options.matchProp] || selectedSource)
 
       this.options.itemSelected($selectedItem, $selectedItem.attr('data-value'), selectedSource[this.options.matchProp], selectedSource)
       return this.hide()

--- a/lib/bootstrap-typeahead.js
+++ b/lib/bootstrap-typeahead.js
@@ -179,7 +179,7 @@ function($) {
         if (i) {
           var matchItem = $.extend({}, item);
           matchItem[_this.options.valueProp] = _this.highlighter(item[_this.options.matchProp] || item) //store as a prop on the item
-          i.find('a').html(_this.renderTemplate(item)); 
+          i.find('a').html(_this.renderTemplate(matchItem)); 
           return i[0]
         }
       })

--- a/lib/bootstrap-typeahead.js
+++ b/lib/bootstrap-typeahead.js
@@ -161,7 +161,7 @@ function($) {
     ,
     renderTemplate: function(item){
       //leverage underscore's implementation for templating if possible
-      if (_ != null && typeof _.template === "function" ) {
+      if (window._ != null && typeof window._.template === "function" ) {
          return _(this.options.template).template(item)
       //If they're working without underscore (really? wtf-sad-haxors :'( ),use
       // j.resigs super-dope micro-templating (which is coincidentally what underscore uses)

--- a/lib/bootstrap-typeahead.js
+++ b/lib/bootstrap-typeahead.js
@@ -35,8 +35,15 @@ function($) {
     ,
     select: function() {
       var $selectedItem = this.$menu.find('.active')
-      this.$element.val($selectedItem.text())
-      this.options.itemSelected($selectedItem, $selectedItem.attr('data-value'), $selectedItem.text())
+      var _this = this;
+
+      var selectedSource = $.grep(this.source, function(item) {
+        return item[_this.options.valueProp] == $selectedItem.attr('data-value')
+      })[0]
+
+      this.$element.val(selectedSource[this.options.matchProp])
+
+      this.options.itemSelected($selectedItem, $selectedItem.attr('data-value'), selectedSource[this.options.matchProp], selectedSource)
       return this.hide()
     }
 
@@ -178,7 +185,7 @@ function($) {
         i = $(_this.options.item).attr('data-value', item[_this.options.valueProp] || item)
         if (i) {
           var matchItem = $.extend({}, item);
-          matchItem[_this.options.valueProp] = _this.highlighter(item[_this.options.matchProp] || item) //store as a prop on the item
+          matchItem[_this.options.matchProp] = _this.highlighter(item[_this.options.matchProp] || item) //store as a prop on the item
           i.find('a').html(_this.renderTemplate(matchItem)); 
           return i[0]
         }


### PR DESCRIPTION
Adds support for specifying a template for the list item HTML. This allows for including properties other than the match property and greater customization of the list entry. The library looks for underscore.js and leverages it's template processor; if it doesn't exist, it uses John Resig's micro-template function (added to the typeahead class for convenience). Cool cool cool.

The actual array item is now passed back in the itemSelected function in addition to the element, value, and text, preventing the need to look up the object by id.
