### PR TITLE
Accept array of strings for 'val' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation
 2) Download this plugin.
 
 - [ZIP](https://github.com/tcrosen/twitter-bootstrap-typeahead/zipball/master)
-- [Clone in Windows](github-windows://openRepo/https://github.com/tcrosen/twitter-bootstrap-typeahead) 
+- [Clone in Windows](github-windows://openRepo/https://github.com/tcrosen/twitter-bootstrap-typeahead)
 - `git clone git://github.com/tcrosen/twitter-bootstrap-typeahead.git`
 
 3) Include files in your HTML. The minimum required for this plugin are:
@@ -127,7 +127,7 @@ Events
         </td>
     </tr>
 </table>
-		
+
 Options
 -----------------
 
@@ -169,7 +169,7 @@ Options
         </td>
         <td>
             The object required to use a remote datasource.  <br /><i>See also: ajax as a string (below)</i>
-        </td>            
+        </td>
     </tr>
     <tr>
         <td>
@@ -182,8 +182,8 @@ Options
             null
         </td>
         <td>
-            Optionally, a simple URL may be used instead of the AJAX object. <br />   <i>See also: ajax as an object (above)</i>        
-        </td>            
+            Optionally, a simple URL may be used instead of the AJAX object. <br />   <i>See also: ajax as an object (above)</i>
+        </td>
     </tr>
     <tr>
         <td>
@@ -197,7 +197,7 @@ Options
         </td>
         <td>
             The object property to match the query against and highlight in the results.
-        </td>            
+        </td>
     </tr>
     <tr>
         <td>
@@ -259,15 +259,29 @@ Options
         <td>
             val
         </td>
-		<td>
+        <td>
             string
         </td>
-		<td>
+        <td>
             'id'
         </td>
         <td>
             The object property that is returned when an item is selected.
-        </td>        
+        </td>
+    </tr>
+    <tr>
+        <td>
+            val
+        </td>
+		<td>
+            array
+        </td>
+		<td>
+            null
+        </td>
+        <td>
+            The object properties that are returned when an item is selected.
+        </td>
     </tr>
 </table>
 

--- a/lib/bootstrap-typeahead.js
+++ b/lib/bootstrap-typeahead.js
@@ -319,7 +319,16 @@ function ($) {
             var that = this;
 
             items = $(items).map(function (i, item) {
-                i = $(that.options.item).attr('data-value', item[that.options.val]);
+                var inputs = {};
+                if (typeof that.options.val === 'string') {
+                    inputs = item[that.options.val];
+                }
+                else {
+                    $.each(that.options.val, function (i, attr) {
+                        inputs[attr] = item[attr];
+                    });
+                }
+                i = $(that.options.item).attr('data-value', JSON.stringify(inputs));
                 i.find('a').html(that.highlighter(item[that.options.display]));
                 return i[0];
             });
@@ -336,7 +345,7 @@ function ($) {
         select: function () {
             var $selectedItem = this.$menu.find('.active');
             this.$element.val($selectedItem.text()).change();
-            this.options.itemSelected($selectedItem, $selectedItem.attr('data-value'), $selectedItem.text());
+            this.options.itemSelected($selectedItem, JSON.parse($selectedItem.attr('data-value')), $selectedItem.text());
             return this.hide();
         },
 

--- a/tests/typeahead-tests.js
+++ b/tests/typeahead-tests.js
@@ -174,7 +174,32 @@
         typeahead.$menu.remove();
     });
 
-    test('basic ajax url as source should work', function() {    
+
+    test("should handle multiple object values", function () {
+        var $input = $('<input />').typeahead({
+                source: [{ id: 1, name: 'aa', type: 'small' }, { id: 2, name: 'ab', type: 'big' }, { id: 3, name: 'ac', type: 'medium'}],
+                val: ['name', 'type'],
+                itemSelected: function (item,values,text) { vals = values }
+            }),
+          typeahead = $input.data('typeahead'),
+          changed = false;
+
+        $input.val('a');
+        typeahead.lookup();
+
+        $input.change(function () { changed = true });
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click();
+
+        equal($input.val(), 'ac', 'input value was correctly set');
+        equal(vals.toJSON, {'name': 'ac', 'type': 'medium'}.toJSON, 'returns the correct value object');
+        ok(!typeahead.$menu.is(':visible'), 'the menu was hidden');
+        ok(changed, 'a change event was fired');
+
+        typeahead.$menu.remove();
+    });
+
+    test('basic ajax url as source should work', function() {
         var $input = $('<input />').typeahead({ ajax: '/test' }),
             typeahead = $input.data('typeahead');
 


### PR DESCRIPTION
Made some changes which allow the 'val' parameter to accept an Array of strings to store, correlating to attributes from the initial objects. I used JSON.stringify to store objects in the data-value attribute of the items, which is a bit hackish, but in my limited testing corpus it doesn't seem to have any major bugs.

Additional tests were added to cover the new usage, but I'm not totally familiar with the bootstrap test suite so they may be incomplete.

Hope this is useful!
