### PR TITLE
Add full item to call of match and highligther

### DIFF
--- a/lib/bootstrap-typeahead.js
+++ b/lib/bootstrap-typeahead.js
@@ -224,7 +224,7 @@ function ($) {
             } 
 
             items = $.grep(data, function (item) {
-                return that.matcher(item[that.options.display]);
+                return that.matcher(item[that.options.display], item);
             });
 
             return this.sorter(items);                
@@ -320,7 +320,7 @@ function ($) {
 
             items = $(items).map(function (i, item) {
                 i = $(that.options.item).attr('data-value', item[that.options.val]);
-                i.find('a').html(that.highlighter(item[that.options.display]));
+                i.find('a').html(that.highlighter(item[that.options.display], item));
                 return i[0];
             });
 


### PR DESCRIPTION
The fact that the matcher and highlighter functions only get passed the 'display value' of an item, and not the entire item makes some desirable things impossible to do. My use case is that I have a field into which usernames are typed. However, I have the users full names and need to be able to match on these. Since the input only accepts the login, it is not good enough just having the full name as the item's 'display value', I therefore need the matcher and the highlighter to have full access to the item, to which I can add arbitrary data such as the full name (and anything else I please).

The attached changeset passes the full item to the matcher and highlighter functions. The change ought be compatible with all users custom matcher and highlighter functions unless they have done something very exotic. One could also choose to pass just the full item and be incompatible with existing code...  
