### PR TITLE
keypress event got registered twice in Firefox

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -400,12 +400,13 @@ function ($) {
         //
         listen: function () {
             this.$element.on('blur', $.proxy(this.blur, this))
-                         .on('keypress', $.proxy(this.keypress, this))
                          .on('keyup', $.proxy(this.keyup, this));
 
-            if (this.eventSupported('keydown')) {
-               this.$element.on('keydown', $.proxy(this.keypress, this));
-            }
+    		if (this.eventSupported('keydown')) {
+				this.$element.on('keydown', $.proxy(this.keypress, this));
+			} else {
+				this.$element.on('keypress', $.proxy(this.keypress, this));
+			}
 
             this.$menu.on('click', $.proxy(this.click, this))
                       .on('mouseenter', 'li', $.proxy(this.mouseenter, this));


### PR DESCRIPTION
when moving up/down within the typeahead dropdrown in firefox (tested with 16.0.1) you always moved 2 steps ahead/back instead of just one. this was caused because the keypress event got registered twice in the "listen" method.
