### PR TITLE
Issue #19: added support for scrollbar on dropdown menu

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -1,4 +1,4 @@
-﻿//  ----------------------------------------------------------------------------
+//  ----------------------------------------------------------------------------
 //
 //  bootstrap-typeahead.js  
 //
@@ -208,7 +208,7 @@ function ($) {
         lookup: function (event) {
             var that = this,
                 items;
-
+                
             if (that.ajax) {
                 that.ajaxer();
             }
@@ -302,7 +302,7 @@ function ($) {
                 left: pos.left
             });
 
-            this.$menu.show();
+            this.$menu.show();  
             this.shown = true;
 
             return this;
@@ -341,8 +341,8 @@ function ($) {
                 i.find('a').html(that.highlighter(item[that.options.display], item));
                 return i[0];
             });
-
-            items.first().addClass('active');
+      
+                items.first().addClass('active');
             this.$menu.html(items);
             return this;
         },
@@ -363,14 +363,28 @@ function ($) {
         //  Selects the next result
         //
         next: function (event) {
-            var active = this.$menu.find('.active').removeClass('active');
+            var that = this;
+            var $menu = that.$menu;
+            var active = $menu.find('.active');
             var next = active.next();
-
+            var menuHeight = $menu.innerHeight();
+            var bottomPosition;
+            
             if (!next.length) {
                 next = $(this.$menu.find('li')[0]);
             }
-
+            
+            active.removeClass('active');
             next.addClass('active');
+            bottomPosition = next.position().top + next.height();
+            if(menuHeight < bottomPosition){
+                that.avoidMouseEnter = true;
+                $menu.on('mousemove',function(){
+                  that.avoidMouseEnter = false;
+                  $menu.off('mousemove');
+                });
+                $menu.scrollTop($menu.scrollTop() + bottomPosition - menuHeight);
+            }
         },
 
         //------------------------------------------------------------------
@@ -378,14 +392,28 @@ function ($) {
         //  Selects the previous result
         //
         prev: function (event) {
-            var active = this.$menu.find('.active').removeClass('active');
+            var that = this;
+            var $menu = that.$menu;
+            var active = $menu.find('.active');
             var prev = active.prev();
+            var menuScroll = $menu.scrollTop();
+            var topPosition;
 
             if (!prev.length) {
                 prev = this.$menu.find('li').last();
             }
 
+            active.removeClass('active');
             prev.addClass('active');
+            topPosition = menuScroll + prev.position().top;
+            if(menuScroll > topPosition){
+                that.avoidMouseEnter = true;
+                $menu.on('mousemove',function(){
+                  that.avoidMouseEnter = false;
+                  $menu.off('mousemove');
+                });
+                $menu.scrollTop(topPosition);
+            }
         },
 
         //=============================================================================================================
@@ -402,13 +430,13 @@ function ($) {
             this.$element.on('blur', $.proxy(this.blur, this))
                          .on('keyup', $.proxy(this.keyup, this));
 
-    		if (this.eventSupported('keydown')) {
-				this.$element.on('keydown', $.proxy(this.keypress, this));
-			} else {
-				this.$element.on('keypress', $.proxy(this.keypress, this));
-			}
-
-            this.$menu.on('click', $.proxy(this.click, this))
+            if (this.eventSupported('keydown')) {
+               this.$element.on('keydown', $.proxy(this.keypress, this));
+            } else {
+               this.$element.on('keypress', $.proxy(this.keypress, this));
+            }
+            
+            this.$menu.on('mousedown', $.proxy(this.click, this))
                       .on('mouseenter', 'li', $.proxy(this.mouseenter, this));
         },
 
@@ -484,6 +512,10 @@ function ($) {
             var that = this;
             e.stopPropagation();
             e.preventDefault();
+            if(this.keepFocus) {
+              that.$element.focus();
+              this.keepFocus = false;
+            }
             setTimeout(function () {
                 if (!that.$menu.is(':focus')) {
                   that.hide();
@@ -496,9 +528,16 @@ function ($) {
         //  Handles clicking on the results list
         //
         click: function (e) {
-            e.stopPropagation();
-            e.preventDefault();
-            this.select();
+            if(e.which != 1) {
+              return;
+            }
+            if(e.target.tagName == 'A'){
+              e.stopPropagation();
+              e.preventDefault();
+              this.select();
+            } else {
+              this.keepFocus = true;
+            }
         },
 
         //------------------------------------------------------------------
@@ -506,6 +545,10 @@ function ($) {
         //  Handles the mouse entering the results list
         //
         mouseenter: function (e) {
+            if(this.avoidMouseEnter) {
+              this.avoidMouseEnter = false;
+              return;
+            }
             this.$menu.find('.active').removeClass('active');
             $(e.currentTarget).addClass('active');
         }
@@ -556,7 +599,7 @@ function ($) {
     }
 
     $.fn.typeahead.Constructor = Typeahead;
-
+  
     //------------------------------------------------------------------
     //
     //  DOM-ready call for the Data API (no-JS implementation)

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -517,7 +517,7 @@ function ($) {
               this.keepFocus = false;
             }
             setTimeout(function () {
-                if (!that.$menu.is(':focus')) {
+                if (!that.$element.is(':focus')) {
                   that.hide();
                 }
             }, 150)

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -531,7 +531,7 @@ function ($) {
             if(e.which != 1) {
               return;
             }
-            if(e.target.tagName == 'A'){
+            if(e.target.tagName == 'A' || e.target.parentElement.tagName == 'A'){
               e.stopPropagation();
               e.preventDefault();
               this.select();


### PR DESCRIPTION
Implements enhancements needed to give support for features mentioned on issue #19: scrollbar support on menu.

Originally, using CSS, you could force the menu to have a max-height and use a scroll (overflow:auto or overflow-y:auto) to reach the list items that where outside the visual area. However, clicking on the scrollbar that could appear would not work (you could only scroll using the mouse wheel, trackpad gesture or similar). The reason was that any click on it would fire a blur event that would close the menu.

This commit solves this issue by making a difference between clicks on a list item or clicks anywhere else inside the menu (including the scrollbar). The first case will produce the original behavior (item is selected and then the menu is closed). The second one will not select an item and will avoid the closing of the menu (also it will reposition the focus on the input element).

The second part of this enhancement is related with navigation using up and down arrows: now that we have a "hidden" area, we must ensure that any selected item is kept away from that area by forcing the menu to scroll (vertically) accordingly.

In order to achieve this:
- When going up: prev() method now checks if the top border of the newly selectes li element is inside the visible area or not. If not, the menu is scrolled (using jQuery's scrollTop method) to the exact position of that top border (leaving the mentioned element fully visible).
- When going down: next() method does something similar to the previous case but taking in consideration the bottom border of the selected li element

It was also necessary to take care of the mouseenter event that could be triggered when we scroll programmatically (the mouse is not moved, but the elements behind the mouse - the menu items - do move because of the scrolling movement). The solution for that was setting a variable that tells the next mouseenter method invocation to avoid changing the active element, after prev() or next() is called (if the user moves the mouse after prev() or next() the mouseenter can start changing the active element again... this is done in order to avoid messing the expected behavior of mouseenter in cases where prev() or next() makes the menu scroll but the mouse never leaves the element it is currently over, which could happen for small scrolling distances).
