### PR TITLE
Passing the $element as context to itemSelected

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -202,7 +202,7 @@ function ($) {
       select: function () {
         var $selectedItem = this.$menu.find('.active');
         this.$element.val($selectedItem.text()).change();
-        this.options.itemSelected(JSON.parse($selectedItem.attr('data-value')));
+        $.proxy(this.options.itemSelected, this.$element, JSON.parse($selectedItem.attr('data-value')))();
         return this.hide();
       },
 


### PR DESCRIPTION
With the current implementation it is not possible to access this.$element
from the itemSelected function. This comes handy when implementing
several typeaheads in the same page and you need to react in other elements
once the typeahead was selected. By using proxy we are passing the current
element in the context and it can be accessed as 'this' from within 
itemSelected. 

Example:
[...]
itemSelected: function (item) {
    $(this).prev('input[type="hidden"]').val(item);
},
[...]
